### PR TITLE
Implement almacén corte module

### DIFF
--- a/api/insumos/cortes_almacen.php
+++ b/api/insumos/cortes_almacen.php
@@ -1,0 +1,185 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+function abrirCorte($usuarioId) {
+    global $conn;
+    if (!$usuarioId) {
+        error('Usuario requerido');
+    }
+    $stmt = $conn->prepare('INSERT INTO corte_almacen (usuario_abre_id, fecha_inicio) VALUES (?, NOW())');
+    if (!$stmt) {
+        error('Error al preparar: ' . $conn->error);
+    }
+    $stmt->bind_param('i', $usuarioId);
+    if (!$stmt->execute()) {
+        $stmt->close();
+        error('Error al abrir corte: ' . $stmt->error);
+    }
+    $id = $stmt->insert_id;
+    $stmt->close();
+    success(['corte_id' => $id]);
+}
+
+function cerrarCorte($corteId, $usuarioId, $observaciones) {
+    global $conn;
+    if (!$corteId || !$usuarioId) {
+        error('Datos incompletos');
+    }
+    $stmt = $conn->prepare('SELECT fecha_inicio FROM corte_almacen WHERE id = ?');
+    if (!$stmt) {
+        error('Error al obtener corte: ' . $conn->error);
+    }
+    $stmt->bind_param('i', $corteId);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res->num_rows === 0) {
+        $stmt->close();
+        error('Corte no encontrado');
+    }
+    $row = $res->fetch_assoc();
+    $inicio = $row['fecha_inicio'];
+    $stmt->close();
+
+    $upd = $conn->prepare('UPDATE corte_almacen SET usuario_cierra_id = ?, fecha_fin = NOW(), observaciones = ? WHERE id = ?');
+    if (!$upd) {
+        error('Error al preparar cierre: ' . $conn->error);
+    }
+    $upd->bind_param('isi', $usuarioId, $observaciones, $corteId);
+    if (!$upd->execute()) {
+        $upd->close();
+        error('Error al cerrar corte: ' . $upd->error);
+    }
+    $upd->close();
+
+    $mov = $conn->prepare("SELECT insumo_id,
+           SUM(CASE WHEN tipo='entrada' THEN cantidad ELSE 0 END) AS entradas,
+           SUM(CASE WHEN tipo='salida' THEN cantidad ELSE 0 END) AS salidas
+        FROM movimientos_insumos
+        WHERE fecha >= ? AND fecha <= NOW()
+        GROUP BY insumo_id");
+    if (!$mov) {
+        error('Error al calcular movimientos: ' . $conn->error);
+    }
+    $mov->bind_param('s', $inicio);
+    $mov->execute();
+    $rMov = $mov->get_result();
+    $datosMov = [];
+    while ($m = $rMov->fetch_assoc()) {
+        $datosMov[$m['insumo_id']] = [
+            'entradas' => (float)$m['entradas'],
+            'salidas' => (float)$m['salidas']
+        ];
+    }
+    $mov->close();
+
+    $hasMerma = $conn->query("SHOW TABLES LIKE 'mermas_insumo'")->num_rows > 0;
+    $mermas = [];
+    if ($hasMerma) {
+        $mm = $conn->prepare('SELECT insumo_id, SUM(cantidad) AS mermas FROM mermas_insumo WHERE fecha >= ? AND fecha <= NOW() GROUP BY insumo_id');
+        if ($mm) {
+            $mm->bind_param('s', $inicio);
+            $mm->execute();
+            $rm = $mm->get_result();
+            while ($m = $rm->fetch_assoc()) {
+                $mermas[$m['insumo_id']] = (float)$m['mermas'];
+            }
+            $mm->close();
+        }
+    }
+
+    $resIns = $conn->query('SELECT id, nombre, existencia FROM insumos');
+    if (!$resIns) {
+        error('Error al obtener insumos: ' . $conn->error);
+    }
+
+    $hasDetalle = $conn->query("SHOW TABLES LIKE 'corte_almacen_detalle'")->num_rows > 0;
+
+    $detalles = [];
+    while ($ins = $resIns->fetch_assoc()) {
+        $id = (int)$ins['id'];
+        $final = (float)$ins['existencia'];
+        $entradas = isset($datosMov[$id]) ? $datosMov[$id]['entradas'] : 0;
+        $salidas = isset($datosMov[$id]) ? $datosMov[$id]['salidas'] : 0;
+        $merma = isset($mermas[$id]) ? $mermas[$id] : 0;
+        $inicial = $final - $entradas + $salidas + $merma;
+        $d = [
+            'insumo_id' => $id,
+            'insumo' => $ins['nombre'],
+            'inicial' => $inicial,
+            'entradas' => $entradas,
+            'salidas' => $salidas,
+            'mermas' => $merma,
+            'final' => $final
+        ];
+        $detalles[] = $d;
+        if ($hasDetalle) {
+            $conn->query("INSERT INTO corte_almacen_detalle (corte_id, insumo_id, inicial, entradas, salidas, mermas, final) VALUES (
+                $corteId, $id, $inicial, $entradas, $salidas, $merma, $final
+            )");
+        }
+    }
+    success(['mensaje' => 'Corte cerrado', 'detalles' => $detalles]);
+}
+
+function obtenerCortes() {
+    global $conn;
+    $sql = "SELECT c.id, ui.nombre AS abierto_por, c.fecha_inicio, uc.nombre AS cerrado_por, c.fecha_fin
+            FROM corte_almacen c
+            LEFT JOIN usuarios ui ON c.usuario_abre_id = ui.id
+            LEFT JOIN usuarios uc ON c.usuario_cierra_id = uc.id
+            ORDER BY c.id DESC";
+    $res = $conn->query($sql);
+    if (!$res) {
+        error('Error al listar cortes: ' . $conn->error);
+    }
+    $rows = [];
+    while ($r = $res->fetch_assoc()) {
+        $rows[] = $r;
+    }
+    success($rows);
+}
+
+function obtenerDetalleCorte($corteId) {
+    global $conn;
+    $stmt = $conn->prepare("SELECT i.nombre AS insumo, d.inicial, d.entradas, d.salidas, d.mermas, d.final
+        FROM corte_almacen_detalle d
+        JOIN insumos i ON d.insumo_id = i.id
+        WHERE d.corte_id = ?");
+    if (!$stmt) {
+        error('Error al preparar detalle: ' . $conn->error);
+    }
+    $stmt->bind_param('i', $corteId);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $detalles = [];
+    while ($row = $res->fetch_assoc()) {
+        $detalles[] = $row;
+    }
+    $stmt->close();
+    success($detalles);
+}
+
+$accion = $_GET['accion'] ?? $_POST['accion'] ?? '';
+
+switch ($accion) {
+    case 'abrir':
+        $user = isset($_POST['usuario_id']) ? (int)$_POST['usuario_id'] : 0;
+        abrirCorte($user);
+        break;
+    case 'cerrar':
+        $corteId = isset($_POST['corte_id']) ? (int)$_POST['corte_id'] : 0;
+        $user = isset($_POST['usuario_id']) ? (int)$_POST['usuario_id'] : 0;
+        $obs = $_POST['observaciones'] ?? '';
+        cerrarCorte($corteId, $user, $obs);
+        break;
+    case 'listar':
+        obtenerCortes();
+        break;
+    case 'detalle':
+        $cid = isset($_GET['corte_id']) ? (int)$_GET['corte_id'] : 0;
+        obtenerDetalleCorte($cid);
+        break;
+    default:
+        error('Acción no válida');
+}

--- a/uploads/reportes/reporte_corte.php
+++ b/uploads/reportes/reporte_corte.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+
+$corteId = isset($_GET['corte_id']) ? (int)$_GET['corte_id'] : 0;
+if (!$corteId) {
+    die('ID inválido');
+}
+
+$info = $conn->prepare("SELECT c.id, c.fecha_inicio, c.fecha_fin, ua.nombre AS abierto_por, uc.nombre AS cerrado_por
+                        FROM corte_almacen c
+                        LEFT JOIN usuarios ua ON c.usuario_abre_id = ua.id
+                        LEFT JOIN usuarios uc ON c.usuario_cierra_id = uc.id
+                        WHERE c.id = ?");
+$info->bind_param('i', $corteId);
+$info->execute();
+$resInfo = $info->get_result();
+if ($resInfo->num_rows === 0) {
+    die('Corte no encontrado');
+}
+$corte = $resInfo->fetch_assoc();
+$info->close();
+
+header('Content-Type: text/csv; charset=utf-8');
+$filename = 'corte_almacen_' . date('Ymd_Hi') . '.csv';
+header('Content-Disposition: attachment; filename=' . $filename);
+
+$out = fopen('php://output', 'w');
+
+fputcsv($out, ['Corte ID', 'Abierto por', 'Cerrado por', 'Inicio', 'Fin']);
+fputcsv($out, [$corte['id'], $corte['abierto_por'], $corte['cerrado_por'], $corte['fecha_inicio'], $corte['fecha_fin']]);
+fputcsv($out, []);
+fputcsv($out, ['Insumo','Inicial','Entradas','Salidas','Mermas','Final']);
+
+$det = $conn->prepare("SELECT i.nombre, d.inicial, d.entradas, d.salidas, d.mermas, d.final
+                       FROM corte_almacen_detalle d
+                       JOIN insumos i ON d.insumo_id = i.id
+                       WHERE d.corte_id = ?");
+$det->bind_param('i', $corteId);
+$det->execute();
+$resDet = $det->get_result();
+while ($row = $resDet->fetch_assoc()) {
+    fputcsv($out, [$row['nombre'], $row['inicial'], $row['entradas'], $row['salidas'], $row['mermas'], $row['final']]);
+}
+$det->close();
+
+fclose($out);
+exit;

--- a/vistas/insumos/cortes.js
+++ b/vistas/insumos/cortes.js
@@ -1,0 +1,66 @@
+const usuarioId = 1; // reemplazar con id de sesión en producción
+
+async function abrirCorte() {
+    try {
+        const resp = await fetch('../../api/insumos/cortes_almacen.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ accion: 'abrir', usuario_id: usuarioId })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            alert('Corte abierto ID: ' + data.resultado.corte_id);
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al abrir corte');
+    }
+}
+
+async function cerrarCorte() {
+    document.getElementById('formObservaciones').style.display = 'block';
+}
+
+async function guardarCierre() {
+    const obs = document.getElementById('observaciones').value;
+    const corteId = prompt('ID de corte a cerrar');
+    if (!corteId) return;
+    try {
+        const resp = await fetch('../../api/insumos/cortes_almacen.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ accion: 'cerrar', corte_id: corteId, usuario_id: usuarioId, observaciones: obs })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            renderResumen(data.resultado.detalles);
+            document.getElementById('formObservaciones').style.display = 'none';
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cerrar');
+    }
+}
+
+function renderResumen(detalles) {
+    const tbody = document.querySelector('#tablaResumen tbody');
+    tbody.innerHTML = '';
+    detalles.forEach(d => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${d.insumo}</td><td>${d.inicial}</td><td>${d.entradas}</td><td>${d.salidas}</td><td>${d.mermas}</td><td>${d.final}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const a = document.getElementById('btnAbrirCorte');
+    if (a) a.addEventListener('click', abrirCorte);
+    const c = document.getElementById('btnCerrarCorte');
+    if (c) c.addEventListener('click', cerrarCorte);
+    const g = document.getElementById('guardarCierre');
+    if (g) g.addEventListener('click', guardarCierre);
+});

--- a/vistas/insumos/cortes.php
+++ b/vistas/insumos/cortes.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/../../utils/cargar_permisos.php';
+$path_actual = str_replace('/CDI', '', $_SERVER['PHP_SELF']);
+if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
+    http_response_code(403);
+    echo 'Acceso no autorizado';
+    exit;
+}
+$title = 'Cortes Almacén';
+ob_start();
+?>
+<div class="page-header">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h2>Cortes de Almacén</h2>
+            </div>
+            <div class="col-12">
+                <a href="../../index.php">Inicio</a>
+                <a href="">Cortes</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="container mt-4">
+    <div class="mb-3">
+        <button class="btn custom-btn me-2" id="btnAbrirCorte">Abrir corte</button>
+        <button class="btn custom-btn" id="btnCerrarCorte">Cerrar corte</button>
+    </div>
+    <div id="formObservaciones" class="mb-3" style="display:none;">
+        <textarea id="observaciones" class="form-control mb-2" placeholder="Observaciones"></textarea>
+        <button class="btn custom-btn" id="guardarCierre">Guardar cierre</button>
+    </div>
+    <div class="mb-3">
+        <label for="buscarFecha">Fecha:</label>
+        <input type="date" id="buscarFecha" class="form-control-sm">
+        <button class="btn custom-btn-sm" id="btnBuscar">Buscar</button>
+    </div>
+    <div class="table-responsive">
+        <table id="tablaResumen" class="styled-table">
+            <thead>
+                <tr>
+                    <th>Insumo</th>
+                    <th>Inicial</th>
+                    <th>Entradas</th>
+                    <th>Salidas</th>
+                    <th>Mermas</th>
+                    <th>Final</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="cortes.js"></script>
+</body>
+</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../nav.php';
+?>


### PR DESCRIPTION
## Summary
- add `cortes_almacen.php` API with open/close/list/detail actions
- add page and JS for almacén cuts
- add export script `reporte_corte.php`

## Testing
- `php -l api/insumos/cortes_almacen.php`
- `php -l uploads/reportes/reporte_corte.php`
- `php -l vistas/insumos/cortes.php`

------
https://chatgpt.com/codex/tasks/task_e_688c1bd517f4832b994f118f4254c903