### PR TITLE
Fix QR generation flow with persistent summary

### DIFF
--- a/api/bodega/generar_qr.php
+++ b/api/bodega/generar_qr.php
@@ -132,10 +132,12 @@ $up->bind_param('si', $pdf_rel, $idqr);
 $up->execute();
 $up->close();
 
-$mov = $conn->prepare("INSERT INTO movimientos_insumos (tipo, usuario_id, insumo_id, cantidad, qr_token) VALUES ('traspaso', ?, ?, ?, ?)");
+$mov = $conn->prepare("INSERT INTO movimientos_insumos (tipo, usuario_id, insumo_id, cantidad, observacion, fecha, qr_token) VALUES (?, ?, ?, ?, ?, NOW(), ?)");
 foreach ($seleccionados as $s) {
     $neg = -$s['cantidad'];
-    $mov->bind_param('iids', $usuario_id, $s['id'], $neg, $token);
+    $tipo = 'traspaso';
+    $obs = '';
+    $mov->bind_param('siidss', $tipo, $usuario_id, $s['id'], $neg, $obs, $token);
     $mov->execute();
 }
 $mov->close();

--- a/vistas/bodega/generar_qr.php
+++ b/vistas/bodega/generar_qr.php
@@ -80,6 +80,7 @@ const catalogo = <?= json_encode($insumos) ?>;
 let filtrado = catalogo;
 let items = 15;
 let pagina = 1;
+let seleccionados = JSON.parse(localStorage.getItem('qr_actual') || '{}');
 
 function renderTabla(){
     const tbody = document.getElementById('tablaInsumos');
@@ -88,27 +89,37 @@ function renderTabla(){
     const fin = inicio + items;
     filtrado.slice(inicio,fin).forEach(i => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${i.nombre}</td><td>${i.existencia}</td><td>${i.unidad}</td><td><input type="number" step="0.01" min="0" data-id="${i.id}" class="form-control"></td>`;
+        const val = seleccionados[i.id] || '';
+        tr.innerHTML = `<td>${i.nombre}</td><td>${i.existencia}</td><td>${i.unidad}</td><td><input type="number" step="0.01" min="0" data-id="${i.id}" class="form-control" value="${val}"></td>`;
         tbody.appendChild(tr);
     });
     tbody.querySelectorAll('input').forEach(inp=>{
-        inp.addEventListener('input', actualizarResumen);
+        inp.addEventListener('input', onInputChange);
     });
+}
+
+function onInputChange(e){
+    const id = e.target.dataset.id;
+    const val = parseFloat(e.target.value);
+    if(!isNaN(val) && val > 0){
+        seleccionados[id] = val;
+    } else {
+        delete seleccionados[id];
+    }
+    actualizarResumen();
 }
 
 function actualizarResumen(){
     const body = document.querySelector('#tablaResumen tbody');
     body.innerHTML='';
-    document.querySelectorAll('#tablaInsumos input[data-id]').forEach(inp=>{
-        const val = parseFloat(inp.value);
-        if(val>0){
-            const id = parseInt(inp.dataset.id);
-            const ins = catalogo.find(x=>x.id===id);
-            const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${ins.nombre}</td><td>${val}</td><td>${ins.unidad}</td>`;
-            body.appendChild(tr);
-        }
+    Object.entries(seleccionados).forEach(([id,val])=>{
+        const ins = catalogo.find(x=>x.id == id);
+        if(!ins || !ins.nombre || !ins.unidad || val <= 0) return;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${ins.nombre}</td><td>${val}</td><td>${ins.unidad}</td>`;
+        body.appendChild(tr);
     });
+    localStorage.setItem('qr_actual', JSON.stringify(seleccionados));
 }
 
 function filtrar(){
@@ -134,16 +145,11 @@ document.getElementById('nextPag').addEventListener('click',()=>{
 });
 
 renderTabla();
+actualizarResumen();
 
 document.getElementById('btnGenerar').addEventListener('click', async function(e){
     e.preventDefault();
-    const insumos = [];
-    document.querySelectorAll('#formQR input[data-id]').forEach(inp => {
-        const cantidad = parseFloat(inp.value);
-        if(cantidad > 0){
-            insumos.push({id: parseInt(inp.getAttribute('data-id')), cantidad});
-        }
-    });
+    const insumos = Object.entries(seleccionados).map(([id,cantidad])=>({id:parseInt(id), cantidad:parseFloat(cantidad)}));
     if(insumos.length === 0){
         alert('Ingresa cantidades válidas');
         return;
@@ -163,7 +169,11 @@ document.getElementById('btnGenerar').addEventListener('click', async function(e
                 '<p class="text-white">Escanea el código para recibir:</p>'+
                 '<img src="'+img+'" alt="QR" width="200" height="200">'+
                 '<p class="mt-2"><a class="btn custom-btn" href="'+pdf+'" target="_blank">Ver PDF</a></p>'+
-                '<p class="mt-2"><a class="btn custom-btn" href="../../api/bodega/imprimir_qr.php?qrName='+img+'"  target="_blank">Imprimirs PDF</a></p>';
+                '<p class="mt-2"><a class="btn custom-btn" href="../../api/bodega/imprimir_qr.php?qrName='+img+'"  target="_blank">Imprimir PDF</a></p>';
+            seleccionados = {};
+            localStorage.removeItem('qr_actual');
+            renderTabla();
+            actualizarResumen();
            
         } else {
             alert(data.mensaje || 'Error');


### PR DESCRIPTION
## Summary
- fix duplicate entry errors when logging moves on QR generation
- enhance QR generation UI with pagination, summary validation and localStorage recovery
- clear selected items once QR is generated

## Testing
- `composer validate --no-check-publish`
- `php -l vistas/bodega/generar_qr.php`
- `php -l api/bodega/generar_qr.php`


------
https://chatgpt.com/codex/tasks/task_e_688c507fbe88832baf8d5b47f7c05381