### PR TITLE
Fix QR generation JSON handling

### DIFF
--- a/vistas/bodega/generar_qr.php
+++ b/vistas/bodega/generar_qr.php
@@ -160,7 +160,15 @@ document.getElementById('btnGenerar').addEventListener('click', async function(e
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ insumos })
         });
-        const data = await resp.json();
+        const text = await resp.text();
+        let data;
+        try {
+            data = JSON.parse(text);
+        } catch (e) {
+            console.error("Respuesta no es JSON:", text);
+            alert("Error al procesar la respuesta del servidor.");
+            return;
+        }
         if(data.success){
             const url = data.resultado.url;
             const pdf = '../../' + data.resultado.pdf_url;


### PR DESCRIPTION
## Summary
- improve fetch call in `generar_qr.php` view to parse server response safely

## Testing
- `php -l vistas/bodega/generar_qr.php`
- `php -l api/bodega/generar_qr.php`


------
https://chatgpt.com/codex/tasks/task_e_688c548aa278832bae5eb638f757f396