### PR TITLE
Fix corte detalle insert fields

### DIFF
--- a/api/insumos/cortes_almacen.php
+++ b/api/insumos/cortes_almacen.php
@@ -113,10 +113,36 @@ function cerrarCorte($corteId, $usuarioId, $observaciones) {
             'final' => $final
         ];
         $detalles[] = $d;
+
         if ($hasDetalle) {
-            $conn->query("INSERT INTO cortes_almacen_detalle (corte_id, insumo_id, inicial, entradas, salidas, mermas, final) VALUES (
-                $corteId, $id, $inicial, $entradas, $salidas, $merma, $final
-            )");
+            $existencia_inicial = $inicial;
+            $existencia_final   = $final;
+
+            $insert = "INSERT INTO cortes_almacen_detalle (
+                corte_id,
+                insumo_id,
+                existencia_inicial,
+                entradas,
+                salidas,
+                mermas,
+                existencia_final
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+            $stmtDet = $conn->prepare($insert);
+            if ($stmtDet) {
+                $stmtDet->bind_param(
+                    "iiddddd",
+                    $corteId,
+                    $id,
+                    $existencia_inicial,
+                    $entradas,
+                    $salidas,
+                    $merma,
+                    $existencia_final
+                );
+                $stmtDet->execute();
+                $stmtDet->close();
+            }
         }
     }
     success(['mensaje' => 'Corte cerrado', 'detalles' => $detalles]);


### PR DESCRIPTION
## Summary
- correct field names for existencia in corte closure
- use a prepared statement for inserting corte details

## Testing
- `php -l api/insumos/cortes_almacen.php`

------
https://chatgpt.com/codex/tasks/task_e_688c6454eed0832bb95eed59096dfe83