### PR TITLE
Implementa logica completa para cortes de almacen

### DIFF
--- a/api/insumos/cortes_almacen.php
+++ b/api/insumos/cortes_almacen.php
@@ -4,30 +4,87 @@ require_once __DIR__ . '/../../utils/response.php';
 
 function abrirCorte($usuarioId) {
     global $conn;
+
     if (!$usuarioId) {
         error('Usuario requerido');
     }
+
+    // validar si existe un corte abierto para este usuario
+    $check = $conn->prepare('SELECT id FROM cortes_almacen WHERE usuario_abre_id = ? AND fecha_fin IS NULL LIMIT 1');
+    if (!$check) {
+        error('Error al verificar corte: ' . $conn->error);
+    }
+    $check->bind_param('i', $usuarioId);
+    $check->execute();
+    $res = $check->get_result();
+    if ($res && $row = $res->fetch_assoc()) {
+        $check->close();
+        // ya hay un corte abierto, devolver id existente
+        success(['corte_id' => (int)$row['id']]);
+    }
+    $check->close();
+
+    $conn->begin_transaction();
+
     $stmt = $conn->prepare('INSERT INTO cortes_almacen (usuario_abre_id, fecha_inicio) VALUES (?, NOW())');
     if (!$stmt) {
+        $conn->rollback();
         error('Error al preparar: ' . $conn->error);
     }
     $stmt->bind_param('i', $usuarioId);
     if (!$stmt->execute()) {
         $stmt->close();
+        $conn->rollback();
         error('Error al abrir corte: ' . $stmt->error);
     }
-    $id = $stmt->insert_id;
+    $corteId = $stmt->insert_id;
     $stmt->close();
-    success(['corte_id' => $id]);
+
+    // registrar inventario inicial por insumo
+    $resIns = $conn->query('SELECT id, existencia FROM insumos');
+    if (!$resIns) {
+        $conn->rollback();
+        error('Error al obtener insumos: ' . $conn->error);
+    }
+
+    $hasDetalle = $conn->query("SHOW TABLES LIKE 'cortes_almacen_detalle'")->num_rows > 0;
+    if ($hasDetalle) {
+        $insStmt = $conn->prepare('INSERT INTO cortes_almacen_detalle (corte_id, insumo_id, existencia_inicial, entradas, salidas, mermas, existencia_final) VALUES (?, ?, ?, 0, 0, 0, NULL)');
+        if (!$insStmt) {
+            $conn->rollback();
+            error('Error al preparar detalles: ' . $conn->error);
+        }
+
+        while ($ins = $resIns->fetch_assoc()) {
+            $insumoId = (int)$ins['id'];
+            $existencia = (float)$ins['existencia'];
+            $insStmt->bind_param('iid', $corteId, $insumoId, $existencia);
+            if (!$insStmt->execute()) {
+                $insStmt->close();
+                $conn->rollback();
+                error('Error al insertar detalle: ' . $insStmt->error);
+            }
+        }
+        $insStmt->close();
+    }
+
+    $conn->commit();
+    success(['corte_id' => $corteId]);
 }
 
 function cerrarCorte($corteId, $usuarioId, $observaciones) {
     global $conn;
+
     if (!$corteId || !$usuarioId) {
         error('Datos incompletos');
     }
-    $stmt = $conn->prepare('SELECT fecha_inicio FROM cortes_almacen WHERE id = ?');
+
+    $conn->begin_transaction();
+
+    // obtener fecha de inicio del corte y validar que esté abierto
+    $stmt = $conn->prepare('SELECT fecha_inicio FROM cortes_almacen WHERE id = ? AND fecha_fin IS NULL');
     if (!$stmt) {
+        $conn->rollback();
         error('Error al obtener corte: ' . $conn->error);
     }
     $stmt->bind_param('i', $corteId);
@@ -35,30 +92,23 @@ function cerrarCorte($corteId, $usuarioId, $observaciones) {
     $res = $stmt->get_result();
     if ($res->num_rows === 0) {
         $stmt->close();
-        error('Corte no encontrado');
+        $conn->rollback();
+        error('Corte no encontrado o ya cerrado');
     }
     $row = $res->fetch_assoc();
     $inicio = $row['fecha_inicio'];
     $stmt->close();
 
-    $upd = $conn->prepare('UPDATE cortes_almacen SET usuario_cierra_id = ?, fecha_fin = NOW(), observaciones = ? WHERE id = ?');
-    if (!$upd) {
-        error('Error al preparar cierre: ' . $conn->error);
-    }
-    $upd->bind_param('isi', $usuarioId, $observaciones, $corteId);
-    if (!$upd->execute()) {
-        $upd->close();
-        error('Error al cerrar corte: ' . $upd->error);
-    }
-    $upd->close();
-
+    // obtener movimientos por insumo en el rango del corte
     $mov = $conn->prepare("SELECT insumo_id,
-           SUM(CASE WHEN tipo='entrada' THEN cantidad ELSE 0 END) AS entradas,
-           SUM(CASE WHEN tipo='salida' THEN cantidad ELSE 0 END) AS salidas
+            SUM(CASE WHEN tipo='entrada' THEN cantidad ELSE 0 END) AS entradas,
+            SUM(CASE WHEN tipo IN ('salida','traspaso') THEN cantidad ELSE 0 END) AS salidas,
+            SUM(CASE WHEN tipo='ajuste' AND cantidad < 0 THEN ABS(cantidad) ELSE 0 END) AS mermas
         FROM movimientos_insumos
         WHERE fecha >= ? AND fecha <= NOW()
         GROUP BY insumo_id");
     if (!$mov) {
+        $conn->rollback();
         error('Error al calcular movimientos: ' . $conn->error);
     }
     $mov->bind_param('s', $inicio);
@@ -68,84 +118,105 @@ function cerrarCorte($corteId, $usuarioId, $observaciones) {
     while ($m = $rMov->fetch_assoc()) {
         $datosMov[$m['insumo_id']] = [
             'entradas' => (float)$m['entradas'],
-            'salidas' => (float)$m['salidas']
+            'salidas'  => (float)$m['salidas'],
+            'mermas'   => (float)$m['mermas']
         ];
     }
     $mov->close();
 
+    // mermas adicionales si existe tabla mermas_insumo
     $hasMerma = $conn->query("SHOW TABLES LIKE 'mermas_insumo'")->num_rows > 0;
-    $mermas = [];
     if ($hasMerma) {
-        $mm = $conn->prepare('SELECT insumo_id, SUM(cantidad) AS mermas FROM mermas_insumo WHERE fecha >= ? AND fecha <= NOW() GROUP BY insumo_id');
+        $mm = $conn->prepare('SELECT insumo_id, SUM(cantidad) AS merma FROM mermas_insumo WHERE fecha >= ? AND fecha <= NOW() GROUP BY insumo_id');
         if ($mm) {
             $mm->bind_param('s', $inicio);
             $mm->execute();
             $rm = $mm->get_result();
             while ($m = $rm->fetch_assoc()) {
-                $mermas[$m['insumo_id']] = (float)$m['mermas'];
+                $id = $m['insumo_id'];
+                $cantidad = (float)$m['merma'];
+                if (!isset($datosMov[$id])) {
+                    $datosMov[$id] = ['entradas' => 0, 'salidas' => 0, 'mermas' => 0];
+                }
+                $datosMov[$id]['mermas'] += $cantidad;
             }
             $mm->close();
         }
     }
 
-    $resIns = $conn->query('SELECT id, nombre, existencia FROM insumos');
+    // existencia final actual de insumos
+    $resIns = $conn->query('SELECT id, existencia FROM insumos');
     if (!$resIns) {
+        $conn->rollback();
         error('Error al obtener insumos: ' . $conn->error);
     }
+    $existenciasFinales = [];
+    while ($row = $resIns->fetch_assoc()) {
+        $existenciasFinales[$row['id']] = (float)$row['existencia'];
+    }
 
-    $hasDetalle = $conn->query("SHOW TABLES LIKE 'cortes_almacen_detalle'")->num_rows > 0;
+    // obtener existencias iniciales del corte
+    $det = $conn->prepare('SELECT insumo_id, existencia_inicial FROM cortes_almacen_detalle WHERE corte_id = ?');
+    if (!$det) {
+        $conn->rollback();
+        error('Error al obtener detalles: ' . $conn->error);
+    }
+    $det->bind_param('i', $corteId);
+    $det->execute();
+    $resDet = $det->get_result();
+
+    $updDet = $conn->prepare('UPDATE cortes_almacen_detalle SET entradas = ?, salidas = ?, mermas = ?, existencia_final = ? WHERE corte_id = ? AND insumo_id = ?');
+    if (!$updDet) {
+        $det->close();
+        $conn->rollback();
+        error('Error al preparar actualización de detalle: ' . $conn->error);
+    }
 
     $detalles = [];
-    while ($ins = $resIns->fetch_assoc()) {
-        $id = (int)$ins['id'];
-        $final = (float)$ins['existencia'];
-        $entradas = isset($datosMov[$id]) ? $datosMov[$id]['entradas'] : 0;
-        $salidas = isset($datosMov[$id]) ? $datosMov[$id]['salidas'] : 0;
-        $merma = isset($mermas[$id]) ? $mermas[$id] : 0;
-        $inicial = $final - $entradas + $salidas + $merma;
-        $d = [
-            'insumo_id' => $id,
-            'insumo' => $ins['nombre'],
-            'inicial' => $inicial,
-            'entradas' => $entradas,
-            'salidas' => $salidas,
-            'mermas' => $merma,
-            'final' => $final
-        ];
-        $detalles[] = $d;
+    while ($row = $resDet->fetch_assoc()) {
+        $insumoId = (int)$row['insumo_id'];
+        $existenciaInicial = (float)$row['existencia_inicial'];
+        $entradas = $datosMov[$insumoId]['entradas'] ?? 0;
+        $salidas  = $datosMov[$insumoId]['salidas'] ?? 0;
+        $mermas   = $datosMov[$insumoId]['mermas'] ?? 0;
+        $final    = $existenciasFinales[$insumoId] ?? 0;
 
-        if ($hasDetalle) {
-            $existencia_inicial = $inicial;
-            $existencia_final   = $final;
-
-            $insert = "INSERT INTO cortes_almacen_detalle (
-                corte_id,
-                insumo_id,
-                existencia_inicial,
-                entradas,
-                salidas,
-                mermas,
-                existencia_final
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)";
-
-            $stmtDet = $conn->prepare($insert);
-            if ($stmtDet) {
-                $stmtDet->bind_param(
-                    "iiddddd",
-                    $corteId,
-                    $id,
-                    $existencia_inicial,
-                    $entradas,
-                    $salidas,
-                    $merma,
-                    $existencia_final
-                );
-                $stmtDet->execute();
-                $stmtDet->close();
-            }
+        $updDet->bind_param('ddddii', $entradas, $salidas, $mermas, $final, $corteId, $insumoId);
+        if (!$updDet->execute()) {
+            $updDet->close();
+            $det->close();
+            $conn->rollback();
+            error('Error al actualizar detalle: ' . $updDet->error);
         }
+
+        $detalles[] = [
+            'insumo_id' => $insumoId,
+            'inicial'   => $existenciaInicial,
+            'entradas'  => $entradas,
+            'salidas'   => $salidas,
+            'mermas'    => $mermas,
+            'final'     => $final
+        ];
     }
-    success(['mensaje' => 'Corte cerrado', 'detalles' => $detalles]);
+    $updDet->close();
+    $det->close();
+
+    // cerrar corte
+    $upd = $conn->prepare('UPDATE cortes_almacen SET fecha_fin = NOW(), usuario_cierra_id = ?, observaciones = ? WHERE id = ?');
+    if (!$upd) {
+        $conn->rollback();
+        error('Error al preparar cierre: ' . $conn->error);
+    }
+    $upd->bind_param('isi', $usuarioId, $observaciones, $corteId);
+    if (!$upd->execute()) {
+        $upd->close();
+        $conn->rollback();
+        error('Error al cerrar corte: ' . $upd->error);
+    }
+    $upd->close();
+
+    $conn->commit();
+    success(['corte_id' => $corteId, 'detalles' => $detalles]);
 }
 
 function obtenerCortes() {


### PR DESCRIPTION
## Summary
- implement opening and closing of inventory cuts
- record initial inventory when opening a cut
- compute entradas, salidas y mermas al cerrar

## Testing
- `php -l api/insumos/cortes_almacen.php`

------
https://chatgpt.com/codex/tasks/task_e_688cfad15138832ba8ed9f5bbb3c35e7