### PR TITLE
Fix local PhpSpreadsheet integration

### DIFF
--- a/api/insumos/cortes_almacen.php
+++ b/api/insumos/cortes_almacen.php
@@ -346,8 +346,8 @@ function exportarExcel($corteId) {
         $row++;
     }
     $stmt->close();
-    $fileName = 'uploads/reportes/corte_almacen_' . $corteId . '.xlsx';
-    $path = __DIR__ . '/../../' . $fileName;
+    $fileName = '/uploads/reportes/corte_almacen_' . $corteId . '.xlsx';
+    $path = __DIR__ . '/..' . '/..' . $fileName;
     $writer = new Xlsx($spreadsheet);
     $writer->save($path);
     success(['archivo' => $fileName]);

--- a/utils/PhpSpreadsheet/src/Bootstrap.php
+++ b/utils/PhpSpreadsheet/src/Bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+spl_autoload_register(function ($class) {
+    $prefix = 'PhpOffice\\PhpSpreadsheet\\';
+    $baseDir = __DIR__ . '/../';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relativeClass = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+    if (file_exists($file)) {
+        require_once $file;
+    }
+});

--- a/utils/PhpSpreadsheet/src/Spreadsheet.php
+++ b/utils/PhpSpreadsheet/src/Spreadsheet.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../Spreadsheet.php';

--- a/utils/PhpSpreadsheet/src/Writer/Xlsx.php
+++ b/utils/PhpSpreadsheet/src/Writer/Xlsx.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../../Writer/Xlsx.php';


### PR DESCRIPTION
## Summary
- implement a lightweight autoloader for PhpSpreadsheet in `utils/PhpSpreadsheet/src`
- adjust `cortes_almacen.php` to use the local library and output Excel to `/uploads/reportes`

## Testing
- `php -l api/insumos/cortes_almacen.php`
- `php -l utils/PhpSpreadsheet/src/Bootstrap.php`
- `php -l utils/PhpSpreadsheet/src/Spreadsheet.php`
- `php -l utils/PhpSpreadsheet/src/Writer/Xlsx.php`


------
https://chatgpt.com/codex/tasks/task_e_688d56ed5680832b92c67f6b20870aeb