### PR TITLE
Fix PhpSpreadsheet cache usage in cortes_almacen

### DIFF
--- a/api/insumos/cortes_almacen.php
+++ b/api/insumos/cortes_almacen.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../utils/response.php';
 require_once __DIR__ . '/../../utils/PhpSpreadsheet/src/Bootstrap.php';
 require_once __DIR__ . '/../../utils/PhpSpreadsheet/src/Spreadsheet.php';
 require_once __DIR__ . '/../../utils/PhpSpreadsheet/src/Writer/Xlsx.php';
+require_once __DIR__ . '/../../utils/PhpSpreadsheet/Settings.php';
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
@@ -329,6 +330,9 @@ function exportarExcel($corteId) {
     $stmt->execute();
     $res = $stmt->get_result();
 
+    \PhpOffice\PhpSpreadsheet\Settings::setCacheStorageMethod(
+        \PhpOffice\PhpSpreadsheet\Settings::CACHE_MEMORY
+    );
     $spreadsheet = new Spreadsheet();
     $sheet = $spreadsheet->getActiveSheet();
     $sheet->fromArray(['Insumo','Unidad','Inicial','Entradas','Salidas','Mermas','Final'], NULL, 'A1');


### PR DESCRIPTION
## Summary
- load `Settings.php` from our local PhpSpreadsheet copy
- force cache storage to use memory before building a workbook

## Testing
- `php -l api/insumos/cortes_almacen.php`


------
https://chatgpt.com/codex/tasks/task_e_688d5a1d0e98832b99293fa137507536