### PR TITLE
Fix PDF generation directory handling

### DIFF
--- a/utils/pdf_simple.php
+++ b/utils/pdf_simple.php
@@ -33,6 +33,12 @@ function generar_pdf_simple($archivo, $titulo, array $lineas) {
     }
     $pdf .= "trailer\n<< /Size " . (count($objs) + 1) . " /Root 1 0 R >>\nstartxref\n$xref\n%%EOF";
 
+    // Ensure destination directory exists before saving the PDF
+    $directorio = dirname($archivo);
+    if (!file_exists($directorio)) {
+        mkdir($directorio, 0777, true);
+    }
+
     file_put_contents($archivo, $pdf);
 }
 
@@ -83,6 +89,11 @@ function generar_pdf_con_imagen($archivo, $titulo, array $lineas, $imagen, $x = 
         $pdf .= sprintf("%010d 00000 n \n", $pos[$i]);
     }
     $pdf .= "trailer\n<< /Size " . (count($objs) + 1) . " /Root 1 0 R >>\nstartxref\n$xref\n%%EOF";
+    // Ensure destination directory exists before saving the PDF
+    $directorio = dirname($archivo);
+    if (!file_exists($directorio)) {
+        mkdir($directorio, 0777, true);
+    }
     file_put_contents($archivo, $pdf);
 }
 ?>


### PR DESCRIPTION
## Summary
- ensure destination directories exist before writing PDFs

## Testing
- `php -l utils/pdf_simple.php`


------
https://chatgpt.com/codex/tasks/task_e_688d67827ebc832bae057e9eda46c24e