### PR TITLE
Implement warehouse report export via SimpleXLSXGen

### DIFF
--- a/vistas/insumos/cortes.js
+++ b/vistas/insumos/cortes.js
@@ -113,11 +113,7 @@ async function exportarExcel() {
         return;
     }
     try {
-        const resp = await fetch('../../api/insumos/cortes_almacen.php', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ accion: 'exportar_excel', corte_id: corteActual })
-        });
+        const resp = await fetch(`../../api/insumos/cortes_almacen.php?action=exportarExcel&id=${corteActual}`);
         const data = await resp.json();
         if (data.success) {
             window.open(data.resultado.archivo, '_blank');


### PR DESCRIPTION
## Summary
- remove PhpSpreadsheet dependencies from `cortes_almacen.php`
- use `SimpleXLSXGen.php` to create Excel file
- allow `action=exportarExcel` route with GET support
- update JS to call new endpoint for Excel export

## Testing
- `php -l api/insumos/cortes_almacen.php`
- `node -c vistas/insumos/cortes.js`

------
https://chatgpt.com/codex/tasks/task_e_688d696486a8832ba332366887e3171c