### PR TITLE
Include entry metadata on QR printouts and restyle movement view

### DIFF
--- a/api/insumos/imprimir_qrs_entrada.php
+++ b/api/insumos/imprimir_qrs_entrada.php
@@ -34,7 +34,7 @@ if (empty($ids)) {
 $inPlaceholders = implode(',', array_fill(0, count($ids), '?'));
 $types = str_repeat('i', count($ids));
 
-$sql = "SELECT ei.id, ei.qr, ei.cantidad, ei.unidad, ei.insumo_id, i.nombre AS insumo_nombre
+$sql = "SELECT ei.id, ei.fecha, ei.qr, ei.cantidad, ei.unidad, ei.insumo_id, i.nombre AS insumo_nombre
         FROM entradas_insumos ei
         LEFT JOIN insumos i ON i.id = ei.insumo_id
         WHERE ei.id IN ($inPlaceholders)";
@@ -104,9 +104,20 @@ try {
 
         // Texto debajo del QR: "id - nombre" y "Cant: X unidad"
         $insumoId = (int)($item['insumo_id'] ?? 0);
+        $entradaId = (int)($item['id'] ?? 0);
         $nombre = trim((string)($item['insumo_nombre'] ?? ''));
         $cantidad = rtrim(rtrim(number_format((float)($item['cantidad'] ?? 0), 2, '.', ''), '0'), '.');
         $unidad = trim((string)($item['unidad'] ?? ''));
+        $fechaRegistro = trim((string)($item['fecha'] ?? ''));
+        $fechaLinea = '';
+        if ($fechaRegistro !== '') {
+            try {
+                $dt = new DateTime($fechaRegistro);
+                $fechaLinea = 'Fecha: ' . $dt->format('d/m/Y H:i');
+            } catch (Exception $e) {
+                $fechaLinea = 'Fecha: ' . $fechaRegistro;
+            }
+        }
 
         $lineaNombre = ($insumoId > 0 ? ($insumoId . ' - ') : '') . ($nombre !== '' ? $nombre : '');
         $lineaCantidad = 'Cant: ' . ($cantidad !== '' ? $cantidad : '0') . ($unidad !== '' ? (' ' . $unidad) : '');
@@ -115,6 +126,12 @@ try {
             $printer->text($lineaNombre . "\n");
         }
         $printer->text($lineaCantidad . "\n");
+        if ($fechaLinea !== '') {
+            $printer->text($fechaLinea . "\n");
+        }
+        if ($entradaId > 0) {
+            $printer->text('Lote: ' . $entradaId . "\n");
+        }
         $printer->feed(2);
         $printer->cut();
     }

--- a/vistas/insumos/consulta_movimiento.php
+++ b/vistas/insumos/consulta_movimiento.php
@@ -17,91 +17,55 @@ $idPreset = isset($_GET['id']) ? (int) $_GET['id'] : 0;
     <title>Consulta de movimiento de insumo</title>
     <link href="<?= $baseUrl ? $baseUrl : '' ?>/utils/css/bootstrap.min.css" rel="stylesheet">
     <link href="<?= $baseUrl ? $baseUrl : '' ?>/utils/css/style1.css" rel="stylesheet">
-    <style>
-        body {
-            background: #f7f8fa;
-        }
-        .consulta-header {
-            text-align: center;
-            margin-bottom: 2rem;
-        }
-        .consulta-header h1 {
-            font-size: 1.75rem;
-            font-weight: 700;
-            color: #2c3e50;
-        }
-        .consulta-header p {
-            color: #6c757d;
-            margin-bottom: 0;
-        }
-        .card-info {
-            border: none;
-            border-radius: 1rem;
-        }
-        .card-info .card-body {
-            padding: 2rem;
-        }
-        .info-label {
-            font-weight: 600;
-            color: #495057;
-        }
-        .texto-importante {
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: #1f3c88;
-        }
-        code {
-            color: #c7254e;
-            background-color: #f9f2f4;
-            border-radius: 4px;
-            padding: 2px 4px;
-        }
-        #mov-qr-img {
-            max-width: 240px;
-        }
-    </style>
 </head>
 <body>
-<div class="container py-4 py-md-5">
-    <div class="consulta-header">
-        <h1>Consulta de movimiento de insumo</h1>
-        <p>Información vinculada al código QR de salida.</p>
+<div class="container py-5">
+    <div class="section-header text-center">
+        <p>Movimientos de insumos</p>
+        <h2>Consulta de movimiento</h2>
     </div>
 
-    <div id="mov-status" class="alert alert-info">Buscando información del movimiento...</div>
-
-    <div id="mov-detalle" class="card card-info shadow-sm d-none">
-        <div class="card-body">
-            <h2 class="texto-importante mb-3">Movimiento <span id="mov-id">—</span></h2>
-            <dl class="row">
-                <dt class="col-sm-4 info-label">Tipo</dt>
-                <dd class="col-sm-8" id="mov-tipo">—</dd>
-                <dt class="col-sm-4 info-label">Fecha</dt>
-                <dd class="col-sm-8" id="mov-fecha">—</dd>
-                <dt class="col-sm-4 info-label">Insumo</dt>
-                <dd class="col-sm-8" id="mov-insumo">—</dd>
-                <dt class="col-sm-4 info-label">Cantidad</dt>
-                <dd class="col-sm-8" id="mov-cantidad">—</dd>
-                <dt class="col-sm-4 info-label">Usuario</dt>
-                <dd class="col-sm-8" id="mov-usuario">—</dd>
-                <dt class="col-sm-4 info-label">Usuario destino</dt>
-                <dd class="col-sm-8" id="mov-usuario-destino">—</dd>
-                <dt class="col-sm-4 info-label">Observación</dt>
-                <dd class="col-sm-8" id="mov-observacion">—</dd>
-            </dl>
-            <div class="mt-3">
-                <p class="mb-1 text-muted">Token del movimiento: <code id="mov-token">—</code></p>
-                <p class="mb-1 text-muted">URL de consulta: <code id="mov-consulta-url">—</code></p>
-            </div>
-            <div id="mov-qr-section" class="text-center mt-4 d-none">
-                <img id="mov-qr-img" src="" alt="Código QR del movimiento" class="img-fluid mb-2">
-                <p class="small"><a id="mov-qr-link" href="#" target="_blank" rel="noopener">Descargar código QR</a></p>
-            </div>
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div id="mov-status" class="alert alert-info shadow-sm">Buscando información del movimiento...</div>
         </div>
     </div>
 
-    <div class="text-center mt-4">
-        <a class="btn btn-outline-secondary" href="<?= $baseUrl ? $baseUrl : '' ?>/index.php">Ir al inicio</a>
+    <div class="row justify-content-center mt-4">
+        <div class="col-lg-8">
+            <div id="mov-detalle" class="card bg-dark border-0 shadow-lg text-white d-none">
+                <div class="card-body p-4">
+                    <h2 class="h4 fw-bold text-uppercase mb-4">Movimiento <span id="mov-id" class="text-danger">—</span></h2>
+                    <dl class="row g-3 mb-0">
+                        <dt class="col-sm-4 text-white-50 text-uppercase small">Tipo</dt>
+                        <dd class="col-sm-8" id="mov-tipo">—</dd>
+                        <dt class="col-sm-4 text-white-50 text-uppercase small">Fecha</dt>
+                        <dd class="col-sm-8" id="mov-fecha">—</dd>
+                        <dt class="col-sm-4 text-white-50 text-uppercase small">Insumo</dt>
+                        <dd class="col-sm-8" id="mov-insumo">—</dd>
+                        <dt class="col-sm-4 text-white-50 text-uppercase small">Cantidad</dt>
+                        <dd class="col-sm-8" id="mov-cantidad">—</dd>
+                        <dt class="col-sm-4 text-white-50 text-uppercase small">Usuario</dt>
+                        <dd class="col-sm-8" id="mov-usuario">—</dd>
+                        <dt class="col-sm-4 text-white-50 text-uppercase small">Usuario destino</dt>
+                        <dd class="col-sm-8" id="mov-usuario-destino">—</dd>
+                        <dt class="col-sm-4 text-white-50 text-uppercase small">Observación</dt>
+                        <dd class="col-sm-8" id="mov-observacion">—</dd>
+                    </dl>
+                    <div class="border-top border-secondary mt-4 pt-3 text-white-50 small">
+                        <p class="mb-2">Token del movimiento: <span id="mov-token" class="badge bg-secondary text-uppercase">—</span></p>
+                        <p class="mb-0">URL de consulta: <span id="mov-consulta-url" class="badge bg-secondary text-break">—</span></p>
+                    </div>
+                    <div id="mov-qr-section" class="text-center mt-4 d-none">
+                        <img id="mov-qr-img" src="" alt="Código QR del movimiento" class="img-fluid mb-3" style="max-width: 240px;">
+                        <p class="small mb-0"><a id="mov-qr-link" href="#" target="_blank" rel="noopener" class="text-decoration-none text-light">Descargar código QR</a></p>
+                    </div>
+                </div>
+            </div>
+            <div class="text-center mt-4">
+                <a class="btn custom-btn" href="<?= $baseUrl ? $baseUrl : '' ?>/index.php">Ir al inicio</a>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/vistas/insumos/insumos.js
+++ b/vistas/insumos/insumos.js
@@ -56,6 +56,37 @@ const formatMoneda = (valor) => {
     return Number.isFinite(num) ? num.toFixed(2) : (valor ?? '');
 };
 
+function formatFechaEntrada(fechaStr) {
+    if (!fechaStr) {
+        return '';
+    }
+    const texto = String(fechaStr).trim();
+    if (!texto) {
+        return '';
+    }
+    const normalizado = texto.replace(' ', 'T').replace(/\.\d+$/, '');
+    const fecha = new Date(normalizado);
+    if (!Number.isNaN(fecha.getTime())) {
+        try {
+            return fecha.toLocaleString('es-MX', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+            });
+        } catch (e) {
+            const yyyy = fecha.getFullYear();
+            const mm = String(fecha.getMonth() + 1).padStart(2, '0');
+            const dd = String(fecha.getDate()).padStart(2, '0');
+            const hh = String(fecha.getHours()).padStart(2, '0');
+            const min = String(fecha.getMinutes()).padStart(2, '0');
+            return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+        }
+    }
+    return texto;
+}
+
 
 function showAppMsg(msg) {
     const body = document.querySelector('#appMsgModal .modal-body');
@@ -780,6 +811,9 @@ function mostrarResumenEntrada(entradas, resumenProductos) {
         const nombre = res && res.nombre ? res.nombre : (res && res.insumo_id ? ('ID ' + res.insumo_id) : '');
         const cant = (res && typeof res.cantidad !== 'undefined') ? res.cantidad : '';
         const unidad = (res && res.unidad) ? res.unidad : '';
+        const fechaTexto = formatFechaEntrada(ent && ent.fecha ? ent.fecha : '');
+        const cantidadTexto = (cant !== '' ? `Cantidad: ${cant}${unidad ? ' ' + unidad : ''}` : '');
+        const loteTexto = eid ? `Lote: ${eid}` : '';
 
         const col = document.createElement('div');
         col.className = 'col-12 col-sm-6 col-md-4 col-lg-3';
@@ -789,8 +823,9 @@ function mostrarResumenEntrada(entradas, resumenProductos) {
                     ${imgSrc ? `<img src="${imgSrc}" alt="QR" style="width:180px;height:180px;object-fit:contain;"/>` : ''}
                     <div class="mt-2" style="font-size: 0.9rem;">
                         ${nombre ? `<div><strong>${nombre}</strong></div>` : ''}
-                        <div>${cant !== '' ? `Cantidad: ${cant}${unidad ? ' ' + unidad : ''}` : ''}</div>
-                        ${eid ? `<div class="text-muted" style="font-size:0.8rem;">Entrada #${eid}</div>` : ''}
+                        ${cantidadTexto ? `<div>${cantidadTexto}</div>` : ''}
+                        ${fechaTexto ? `<div class="text-muted" style="font-size:0.8rem;">Fecha: ${fechaTexto}</div>` : ''}
+                        ${loteTexto ? `<div class="text-muted" style="font-size:0.8rem;">${loteTexto}</div>` : ''}
                     </div>
                 </div>
             </div>`;


### PR DESCRIPTION
## Summary
- include the stored entry date when building the entry response metadata
- append entry date and lote information to QR printouts and the entry summary cards in the insumos view
- restyle the movimiento consultation page to reuse the global style1 theme

## Testing
- php -l api/insumos/crear_entrada.php
- php -l api/insumos/imprimir_qrs_entrada.php
- php -l vistas/insumos/consulta_movimiento.php

------
https://chatgpt.com/codex/tasks/task_e_68ca34570a98832bb25edb0bf9e87468