### PR TITLE
Corrige cantidad actual y proveedor en impresión de entradas

### DIFF
--- a/api/insumos/crear_entrada.php
+++ b/api/insumos/crear_entrada.php
@@ -139,7 +139,7 @@ try {
         }
         $selInsumo->free_result();
 
-        $cantidadActual = $existenciaActual + $cantidad;
+        $cantidadActual = $cantidad;
         $qrPlaceholder = 'pendiente';
 
         $insEntrada->bind_param(

--- a/api/insumos/imprimir_qrs_entrada.php
+++ b/api/insumos/imprimir_qrs_entrada.php
@@ -34,9 +34,10 @@ if (empty($ids)) {
 $inPlaceholders = implode(',', array_fill(0, count($ids), '?'));
 $types = str_repeat('i', count($ids));
 
-$sql = "SELECT ei.id, ei.fecha, ei.qr, ei.cantidad, ei.unidad, ei.insumo_id, i.nombre AS insumo_nombre
+$sql = "SELECT ei.id, ei.fecha, ei.qr, ei.cantidad, ei.unidad, ei.insumo_id, i.nombre AS insumo_nombre, p.nombre AS proveedor_nombre
         FROM entradas_insumos ei
         LEFT JOIN insumos i ON i.id = ei.insumo_id
+        LEFT JOIN proveedores p ON p.id = ei.proveedor_id
         WHERE ei.id IN ($inPlaceholders)";
 
 $stmt = $conn->prepare($sql);
@@ -102,13 +103,12 @@ try {
         $printer->bitImage($img);
         $printer->feed(1);
 
-        // Texto debajo del QR: "id - nombre" y "Cant: X unidad"
+        // Texto debajo del QR: "id - nombre" y "Proveedor: ..."
         $insumoId = (int)($item['insumo_id'] ?? 0);
         $entradaId = (int)($item['id'] ?? 0);
         $nombre = trim((string)($item['insumo_nombre'] ?? ''));
-        $cantidad = rtrim(rtrim(number_format((float)($item['cantidad'] ?? 0), 2, '.', ''), '0'), '.');
-        $unidad = trim((string)($item['unidad'] ?? ''));
         $fechaRegistro = trim((string)($item['fecha'] ?? ''));
+        $proveedor = trim((string)($item['proveedor_nombre'] ?? ''));
         $fechaLinea = '';
         if ($fechaRegistro !== '') {
             try {
@@ -120,12 +120,12 @@ try {
         }
 
         $lineaNombre = ($insumoId > 0 ? ($insumoId . ' - ') : '') . ($nombre !== '' ? $nombre : '');
-        $lineaCantidad = 'Cant: ' . ($cantidad !== '' ? $cantidad : '0') . ($unidad !== '' ? (' ' . $unidad) : '');
+        $lineaProveedor = 'Proveedor: ' . ($proveedor !== '' ? $proveedor : 'N/D');
 
         if ($lineaNombre !== '') {
             $printer->text($lineaNombre . "\n");
         }
-        $printer->text($lineaCantidad . "\n");
+        $printer->text($lineaProveedor . "\n");
         if ($fechaLinea !== '') {
             $printer->text($fechaLinea . "\n");
         }


### PR DESCRIPTION
## Summary
- ajusta la cantidad_actual almacenada al registrar entradas para que coincida con la cantidad ingresada
- agrega el proveedor a la consulta de impresión de QR y muestra su nombre en lugar de la cantidad

## Testing
- php -l api/insumos/crear_entrada.php
- php -l api/insumos/imprimir_qrs_entrada.php

------
https://chatgpt.com/codex/tasks/task_e_68ca3be80be4832b9ee8bc534c3ddb9f